### PR TITLE
Remove Google Maps API key.

### DIFF
--- a/src/main/resources/org/onebusaway/gtfs_realtime/visualizer/index.html
+++ b/src/main/resources/org/onebusaway/gtfs_realtime/visualizer/index.html
@@ -24,7 +24,7 @@
            src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js">
   </script>
   <script type="text/javascript"
-           src="http://maps.googleapis.com/maps/api/js?key=AIzaSyCH2jT3jOgHkOe18MjstexVZdO-XZ-88Xo&sensor=false">
+           src="http://maps.googleapis.com/maps/api/js?sensor=false">
   </script>
   <script type="text/javascript" src="index.js"></script>
   <link href="index.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Google Maps API v3 no longer requires a key; omitting the key makes it
easier to get the visualizer up and running quickly.
