### PR TITLE
Increase websocket binary size

### DIFF
--- a/src/main/java/org/onebusaway/gtfs_realtime/visualizer/VisualizerService.java
+++ b/src/main/java/org/onebusaway/gtfs_realtime/visualizer/VisualizerService.java
@@ -90,6 +90,7 @@ public class VisualizerService {
       _webSocketFactory = new WebSocketClientFactory();
       _webSocketFactory.start();
       _webSocketClient = _webSocketFactory.newWebSocketClient();
+      _webSocketClient.setMaxBinaryMessageSize(16384000); 
       _incrementalWebSocket = new IncrementalWebSocket();
       _webSocketConnection = _webSocketClient.open(_vehiclePositionsUri,
           _incrementalWebSocket);


### PR DESCRIPTION
Buffer increase was necessary to avoid the following error:
"WARN:oejw.WebSocketConnectionRFC6455:Frame discarded. Binary aggregation disabed for SCEP@fdbc27{l(/0:0:0:0:0:0:0:1:51199)<->r(/0:0:0:0:0:0:0:1:8081),d=true,open=true,ishut=false,oshut=false,rb=false,wb=false,w=true,i=1r}-{WebSocketServletConnectionRFC6455 p=WebSocketParserRFC6455@1264bf5 state=DATA buffer= g=WebSocketGeneratorRFC6455@144d0c6 closed=false buffer=-1}"
